### PR TITLE
implemented IsEmpty for ()

### DIFF
--- a/is_empty/src/lib.rs
+++ b/is_empty/src/lib.rs
@@ -106,6 +106,12 @@ impl<T> IsEmpty for std::option::Option<T> {
     }
 }
 
+impl IsEmpty for () {
+    fn is_empty(&self) -> bool {
+        true
+    }
+}
+
 /// Thin wrapper function around [IsEmpty::is_empty]. Use it with serde's skip_serializing_if attribute.
 /// ```
 /// use is_empty::IsEmpty;

--- a/is_empty/src/lib.rs
+++ b/is_empty/src/lib.rs
@@ -112,6 +112,12 @@ impl IsEmpty for () {
     }
 }
 
+impl<T> IsEmpty for Vec<T> {
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
+}
+
 /// Thin wrapper function around [IsEmpty::is_empty]. Use it with serde's skip_serializing_if attribute.
 /// ```
 /// use is_empty::IsEmpty;


### PR DESCRIPTION
Implemented `IsEmpty` for `()` as always returning `true`.